### PR TITLE
Fixed problem with QR code not redirecting to validation page

### DIFF
--- a/sgce/certificates/templates/certificates/certificate/pdf/certificate.html
+++ b/sgce/certificates/templates/certificates/certificate/pdf/certificate.html
@@ -75,8 +75,8 @@
                     text-align: {{ certificate.template.footer_text_align }};
                     color: {{ certificate.template.footer_text_color }};">
             <p>
-                {% if certificate.has_qrcode %}
-                    {% qr_from_text "https://sgce.ifal.edu.br/sgce/certificados/validar/{{ certificate.hash }}" size="2" image_format="png" error_correction="L" %} <br/>
+                {% if certificate.has_qrcode %}                    
+                    {% qr_from_text domain|add:"/certificates/certificate/"|add:certificate.hash size="2" image_format="png" error_correction="L" %} <br/>
                     Este documento dispensa o uso de assinatura, <br/>
                     a autenticidade pode ser verificada através da URL: <br/>
                     {{ domain }}/certificates/certificate/{{ certificate.hash }}/


### PR DESCRIPTION
_qr_from_text_ gerava um QR code a partir de um literal string. Foi utilizada a sintaxe de concatenação de templates 'add' para utilizar as variáveis _domain_ e _certificate.hash_